### PR TITLE
Add bottom margin to lists

### DIFF
--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -834,6 +834,7 @@
     ul,
     ol {
       margin-left: 1em;
+      margin-bottom: 1em;
     }
 
     ul {


### PR DESCRIPTION
This is a pull request on your rich text pull request to Mastodon (so your `features/accept-rich-text` branch). It adds a bottom margin to lists.

Before:

<img width="367" alt="image" src="https://user-images.githubusercontent.com/266454/57975400-039cee80-797d-11e9-8d97-c0e96d2b20a2.png">

After:

<img width="372" alt="image" src="https://user-images.githubusercontent.com/266454/57975402-0ac3fc80-797d-11e9-8b21-be92089b2ce8.png">
